### PR TITLE
Correct small typos, add Beam-Warming test case for LTE with sinusoidal data

### DIFF
--- a/+Error/calcOOC.m
+++ b/+Error/calcOOC.m
@@ -13,7 +13,7 @@ function [ dx, err, ooc ] = calcOOC( config, exact, nx, p, relative )
 %			  Default is false.
 %
 %   Example:
-%      exact = Error.exact_LinAdv(config.initial);
+%      exact = Error.exact_linAdv(config.initial);
 %      [dx,err,ooc] = calcOOC(exact, config, 100:100:500, 1);
 %   Calculates the order of convergence of the scheme specified by the
 %   Configuration object 'config' over mesh sizes 100,200,...,500 in the

--- a/+Error/calcOOC_refine.m
+++ b/+Error/calcOOC_refine.m
@@ -14,7 +14,7 @@ function [ dx, err, ooc ] = calcOOC_refine( config, exact, mesh0, n, p, relative
 %			  Default is false.
 %
 %   Example:
-%      exact = Error.exact_LinAdv(config.initial);
+%      exact = Error.exact_linAdv(config.initial);
 %      [dx,err,ooc] = calcOOC(exact, config, 100:100:500, 1);
 %   Calculates the order of convergence of the scheme specified by the
 %   Configuration object 'config' over mesh sizes 100,200,...,500 in the

--- a/+Notes/+Chapter5/linAdv_LW_OOC.m
+++ b/+Notes/+Chapter5/linAdv_LW_OOC.m
@@ -15,7 +15,7 @@ function [nx, err, ooc] = linAdv_LW_OOC
 
 	%% Calculate rate of convergence
 	% Exact solution of the linear advection equation
-	exact = Error.exact_LinAdv(conf.initial);
+	exact = Error.exact_linAdv(conf.initial);
 	% Which mesh sizes to compute over
 	nx = 10 * 2.^(1:8);
 	% Calculate the approximate rate of convergence.

--- a/+Notes/+Chapter5/linAdv_Upw_OOC.m
+++ b/+Notes/+Chapter5/linAdv_Upw_OOC.m
@@ -15,7 +15,7 @@ function [nx, err, ooc] = linAdv_Upw_OOC
 
 	%% Calculate rate of convergence
 	% Exact solution of the linear advection equation
-	exact = Error.exact_LinAdv(conf.initial);
+	exact = Error.exact_linAdv(conf.initial);
 	% Which mesh sizes to compute over
 	nx = 10 * 2.^(1:8);
 	% Calculate the approximate rate of convergence.

--- a/+Notes/+Chapter5/linAdv_beamWarm_Upw_since.m
+++ b/+Notes/+Chapter5/linAdv_beamWarm_Upw_since.m
@@ -1,0 +1,38 @@
+function linAdv_LW_Upw_sine
+	conf = Configuration;
+	conf.model = Model.LinAdv;
+	conf.model.a = 1;
+	conf.timeInt = @TimeIntegration.FE;
+	conf.tMax = 10;
+	conf.CFL = 0.8;
+	conf.initial = @(x) sin(4*pi*x);
+	conf.mesh = Mesh.Cartesian([0,1], 50);
+	conf.bc = Mesh.BC.Periodic;
+  
+  % Run Upwind
+	conf.solver = Flux.LinAdv.Upwind;
+    solnUpw = runSolver(conf);
+	[t, uUpw] = solnUpw.getFinal();
+	
+	% Run Beam-Warming: 
+  % Exact propagation + backwards linear reconstruction + forward Euler time discretization.
+	conf.solver = Flux.LinAdv.Exact_2nd;
+  conf.reconstr = Reconstr.SlopeLimiter(Reconstr.Backward);
+    solnLW = runSolver(conf);
+	[t, uLW] = solnLW.getFinal();
+	
+	% Exact solution
+	x = linspace(0,1,1000);
+	u = sin(4*pi*x);
+
+	% Display data
+	fig = figure();
+	plot(x, u, 'k-');
+	hold on;
+	Plot.plotFrame(solnLW, uLW, t, 0, fig, '', 'bo-');
+	Plot.plotFrame(solnUpw, uUpw, t, 0, fig, '', 'rs-');
+	title('');
+	legend({'Exact', 'Beam-Warming', 'Upwind'});
+	Plot.makeNice();
+	Plot.saveFig('LW,upwind_comparison');
+end

--- a/+Notes/+Chapter5/linAdv_beamWarm_Upw_since.m
+++ b/+Notes/+Chapter5/linAdv_beamWarm_Upw_since.m
@@ -1,4 +1,4 @@
-function linAdv_LW_Upw_sine
+function linAdv_beamWarm_Upw_sine
 	conf = Configuration;
 	conf.model = Model.LinAdv;
 	conf.model.a = 1;
@@ -34,5 +34,5 @@ function linAdv_LW_Upw_sine
 	title('');
 	legend({'Exact', 'Beam-Warming', 'Upwind'});
 	Plot.makeNice();
-	Plot.saveFig('LW,upwind_comparison');
+	Plot.saveFig('BW, upwind_comparison');
 end


### PR DESCRIPTION
In some files with the `OOC` ending `exact_LinAdv` had an upper case `L` instead of the lowercase `l`. 

Furthermore, I added an application of the Beam-Warming scheme for the sinusoidal inital data [Equation (5.2) in this years lecture notes]. This is sort of the contemplary example to Figure 5.3 (in this years lecture notes), where Lax-Wendroff is compared to upwind and the exact solution. 
The purpose of this addition is that one can see that Beam-Warming travels in front of the correct solution, while Lax-Wendroff trails behind.